### PR TITLE
Use ANDROID_NDK_ROOT value for NDK_PATH if present

### DIFF
--- a/jni/Makefile
+++ b/jni/Makefile
@@ -1,4 +1,5 @@
-NDK_PATH=/opt/android-ndk-r10c
+NDK_PATH="$(ANDROID_NDK_ROOT)"
+NDK_PATH?=/opt/android-ndk-r10c
 
 APP=pts-multicall
 BIN=../libs/armeabi/$(APP)


### PR DESCRIPTION
Best practice to set the root of the Android NDK is exporting the
ANDROID_NDK_ROOT variable globally. This change uses ANDROID_NDK_ROOT
value if the variable is defined.
